### PR TITLE
Add multiple compatiable version on version switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_Store
+file/*
 node_modules/
 *.temp

--- a/src/generate-site/template.mustache
+++ b/src/generate-site/template.mustache
@@ -26,6 +26,7 @@
                 }
             }
         }
+
         function showLastCompatibility(event) {
             const elements = document.getElementsByClassName('last-compatible')
             for(let i = 0; i<elements.length; i++) {
@@ -85,7 +86,7 @@
                             </td>
                             {{#compatibilityMatrix}}
                                 <td class="align-middle text-center version-column {{columnName}}">
-                                    {{#.}}
+                                    {{#items}}
                                         {{#pluginVersion}}
                                             <span class="text-nowrap">
                                                  {{#travisStatusPassed}}
@@ -112,7 +113,7 @@
                                         {{#noData}}
                                             <small class="muted">-</small>
                                         {{/noData}}
-                                    {{/.}}
+                                    {{/items}}
                                 </td>
                                 
                             {{/compatibilityMatrix}}


### PR DESCRIPTION
This PR allow to show multiple compatible version of plugins on specific version change . 

Done as part of PKP sprint Hanover 2023 together with https://github.com/basti95(@basti95) and @touhidur . 

Still few part need to finalise but a working prototype has been accomplished that seems very important to systems admins to know which software version have which (multiple) plugins version compatibility . 