### PR TITLE
Run npm install before gulp build for themes compatibility

### DIFF
--- a/src/release/buildRelease.js
+++ b/src/release/buildRelease.js
@@ -8,7 +8,7 @@
  *
  * This helper performs these actions:
  * - prompts the user to run any extra build commands in the current folder (gulp build, composer install etc..)
- * - creates a Tar file from the current folder (in preparation to uploading it as an asset to the Github release)
+ * - creates a Tar file from the current folder (in preparation to uploading it as an asset to the GitHub release)
  */
 const { error, log, warn, info, debug } = require('../utils/log')
 const execa = require('execa')
@@ -48,20 +48,20 @@ module.exports = async ({ pluginName: fileName, repoUrl, branch = 'main' }) => {
       info('No composer.json file found')
     }
 
-    if (fs.existsSync('./gulpfile.js')) {
-      info('Gulp file detected. The tool will run "gulp build".')
-      const { stderr } = await execa('gulp', ['build'])
-      error(stderr)
-    } else {
-      debug('No gulp file file found')
-    }
-
     if (fs.existsSync('./package.json')) {
       info('Package.json file detected. The tool will run "npm install".')
       const { stderr } = await execa('npm', ['install'])
       error(stderr)
     } else {
-      debug('No package.json file file found')
+      debug('No package.json file found')
+    }
+
+    if (fs.existsSync('./gulpfile.js')) {
+      info('Gulp file detected. The tool will run "gulp build".')
+      const { stderr } = await execa('gulp', ['build'])
+      error(stderr)
+    } else {
+      debug('No gulp file found')
     }
   } catch (err) {
     error(err)

--- a/src/release/buildRelease.js
+++ b/src/release/buildRelease.js
@@ -98,7 +98,7 @@ module.exports = async ({ pluginName: fileName, repoUrl, branch = 'main' }) => {
 const deleteExtraFiles = (fileName) => {
   shell.rm('-rf', '.git')
   debug('Deleting files defined in exclusions.txt')
-  const exclusionsFile = shell.head('./exclusions.txt').toString()
+  const exclusionsFile = shell.cat('./exclusions.txt').toString()
   const folderPrefix = new RegExp('^' + fileName + '/')
   exclusionsFile.split('\n').forEach(file => {
     if (!file) return


### PR DESCRIPTION
Currently the tool doesn't work with several officially supported themes (e.g. pragma) as `npm install` needs to run before `gulp build`. I've also switched from `head` to `cat` to cover cases where the `exclusions.txt` file is longer than 10 lines.